### PR TITLE
Fix error dependency issues with old packages

### DIFF
--- a/app/components/AddButton/AddButton.js
+++ b/app/components/AddButton/AddButton.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import './AddButton.scss'
 import '../../assets/images/add-green.svg'
 

--- a/app/components/ApiError/ApiError.js
+++ b/app/components/ApiError/ApiError.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import * as cmsUtils from '../../utils/cmsUtils'
 import './ApiError.scss'
 

--- a/app/components/Buttons/Buttons.js
+++ b/app/components/Buttons/Buttons.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import './Buttons.scss'
 import '../../assets/images/remove-red.svg'
 

--- a/app/components/ConfirmationBox/ConfirmationBox.js
+++ b/app/components/ConfirmationBox/ConfirmationBox.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 
 import './ConfirmationBox.scss'
 

--- a/app/components/IamPrincipalPermissionsFieldSet/IamPrincipalPermissionsFieldSet.js
+++ b/app/components/IamPrincipalPermissionsFieldSet/IamPrincipalPermissionsFieldSet.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import RoleSelect from '../RoleSelect/RoleSelect'
 import Buttons from '../Buttons/Buttons'
 import AddButton from '../AddButton/AddButton'

--- a/app/components/Login/Login.js
+++ b/app/components/Login/Login.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import * as messengerActions from '../../actions/messengerActions'
 import Messenger from '../Messenger/Messenger'

--- a/app/components/LoginMfaForm/LoginMfaForm.js
+++ b/app/components/LoginMfaForm/LoginMfaForm.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { reduxForm, touch } from 'redux-form'
 import { finalizeMfaLogin } from '../../actions/authenticationActions'

--- a/app/components/LoginUserForm/LoginUserForm.js
+++ b/app/components/LoginUserForm/LoginUserForm.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { reduxForm } from 'redux-form'
 import { loginUser } from '../../actions/authenticationActions'

--- a/app/components/Modal/Modal.js
+++ b/app/components/Modal/Modal.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 
 import './Modal.scss'
 

--- a/app/components/SDBDescriptionField/SDBDescriptionField.js
+++ b/app/components/SDBDescriptionField/SDBDescriptionField.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import * as cms from '../../constants/cms'
 
 /**

--- a/app/components/SideBar/views/Category.js
+++ b/app/components/SideBar/views/Category.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import log from 'logger'
 
 /**

--- a/app/components/UserGroupPermissionsFieldSet/UserGroupPermissionsFieldSet.js
+++ b/app/components/UserGroupPermissionsFieldSet/UserGroupPermissionsFieldSet.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import GroupsSelect from '../GroupSelect/GroupsSelect'
 import RoleSelect from '../RoleSelect/RoleSelect'
 import Buttons from '../Buttons/Buttons'

--- a/app/components/VaultBrowser/VaultBrowser.js
+++ b/app/components/VaultBrowser/VaultBrowser.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import './VaultBrowser.scss'
 import AddButton from '../AddButton/AddButton'
 import VaultSecretForm from '../VaultSecretForm/VaultSecretForm'

--- a/app/components/VaultSecret/VaultSecret.js
+++ b/app/components/VaultSecret/VaultSecret.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
+import PropTypes from 'prop-types'
 import VaultSecretForm from '../VaultSecretForm/VaultSecretForm'
 import * as mSDBActions from '../../actions/manageSafetyDepositBoxActions'
 import './VaultSecret.scss'

--- a/package.json
+++ b/package.json
@@ -22,13 +22,17 @@
   "dependencies": {
     "axios": "0.12.0",
     "cookie": "0.3.1",
+    "create-react-class": "^15.5.3",
     "humps": "1.1.0",
     "loglevel": "1.4.1",
+    "prop-types": "15.5.9",
     "react": "15.1.0",
+    "react-addons-create-fragment": "15.1.0",
     "react-addons-css-transition-group": "15.1.0",
     "react-addons-shallow-compare": "15.1.0",
     "react-copy-to-clipboard": "4.1.0",
     "react-dom": "15.1.0",
+    "react-paginate": "4.1.1",
     "react-redux": "4.4.5",
     "react-router": "2.5.1",
     "react-router-redux": "4.0.5",
@@ -36,9 +40,7 @@
     "redux": "3.5.2",
     "redux-form": "5.3.0",
     "redux-logger": "2.6.1",
-    "redux-thunk": "2.1.0",
-    "react-paginate": "4.1.1",
-    "react-addons-create-fragment": "15.1.0"
+    "redux-thunk": "2.1.0"
   },
   "devDependencies": {
     "api-mock": "^0.3.2",


### PR DESCRIPTION
PropTypes was removed from the react package (it seems retroactively), which was breaking the Dashboard builds.

React.createClass functionality is also deprecated, which our version of webpack is still using.

This PR installs `prop-types` and `create-react-class` as a temporary fix.