### PR TITLE
Bugfix: Make sure 'remove timeout' methods are dispatched

### DIFF
--- a/app/actions/authenticationActions.js
+++ b/app/actions/authenticationActions.js
@@ -80,9 +80,11 @@ function handleUserLogin(response, dispatch, redirectToWelcome=true) {
 
     let timeToExpireTokenInMillis = tokenExpiresDate.getTime() - now.getTime()
 
-    setTimeout(() => {
+    let sessionWarningTimeoutId = setTimeout(() => {
         dispatch(warnSessionExpiresSoon(token))
     }, timeToExpireTokenInMillis - 120000)  // warn two minutes before expiration
+
+    dispatch(setSessionWarningTimeoutId(sessionWarningTimeoutId))
 
     let authTokenTimeoutId = setTimeout(() => {
         dispatch(handleSessionExpiration())
@@ -193,8 +195,8 @@ export function refreshAuth(token, redirectPath='/', redirect=true) {
             timeout: AUTH_ACTION_TIMEOUT
         })
         .then(function (response) {
-            handleRemoveAuthTokenTimeout()
-            handleRemoveSessionWarningTimeout()
+            dispatch(handleRemoveAuthTokenTimeout())
+            dispatch(handleRemoveSessionWarningTimeout())
             handleUserLogin(response, dispatch, false)
             if (redirect) {
                 hashHistory.push(redirectPath)
@@ -221,12 +223,12 @@ export function logoutUser(token) {
             timeout: AUTH_ACTION_TIMEOUT
         })
         .then(function () {
-            dispatch(resetAuthState())
             sessionStorage.removeItem('token')
             sessionStorage.removeItem('tokenExpiresDate')
             sessionStorage.removeItem('userRespondedToSessionWarning')
-            handleRemoveAuthTokenTimeout()
-            handleRemoveSessionWarningTimeout()
+            dispatch(handleRemoveAuthTokenTimeout())
+            dispatch(handleRemoveSessionWarningTimeout())
+            dispatch(resetAuthState())
             dispatch(headerActions.mouseOutUsername())
             hashHistory.push('/login')
         })
@@ -245,8 +247,8 @@ export function handleSessionExpiration() {
         sessionStorage.removeItem('token')
         sessionStorage.removeItem('tokenExpiresDate')
         sessionStorage.removeItem('userRespondedToSessionWarning')
-        handleRemoveAuthTokenTimeout()
-        handleRemoveSessionWarningTimeout()
+        dispatch(handleRemoveAuthTokenTimeout())
+        dispatch(handleRemoveSessionWarningTimeout())
         dispatch(expireSession())
         dispatch(modalActions.clearAllModals())
         dispatch(manageSDBActions.resetToInitialState())

--- a/app/reducers/authenticationReducer.js
+++ b/app/reducers/authenticationReducer.js
@@ -37,7 +37,6 @@ export default createReducer(initialState, {
             groups: payload.tokenData.metadata.groups.split(/,/),
             policies: payload.tokenData.policies,
             authTokenTimeoutId: payload.authTokenTimeoutId,
-            sessionWarningTimeoutId: payload.sessionWarningTimeoutId
         })
     },
     // logs the user out and resets user data

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cerberus-management-dashboard",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A management dashboard for Cerberus.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
The remove timeout methods were not called because they were not passed into the `dispatch()` method.